### PR TITLE
HV-644 added jandex-maven-plugin and fixed minor bugs

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -270,6 +270,10 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/jandex/ClassConstraintsJandexBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/jandex/ClassConstraintsJandexBuilder.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.internal.metadata.jandex;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,6 +22,7 @@ import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
+
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -43,10 +45,17 @@ public class ClassConstraintsJandexBuilder extends AbstractConstrainedElementJan
 			return Stream.empty();
 		}
 
+		Set<MetaConstraint<?>> constraints = findMetaConstraints( classInfo.classAnnotations(), beanClass ).collect( Collectors.toSet() );
+
+		// if there are no constraints on a type level - we need to return empty stream
+		if ( constraints.isEmpty() ) {
+			return Stream.empty();
+		}
+		//otherwise we return a stream with one ConstrainedType
 		return Stream.of( new ConstrainedType(
 				ConfigurationSource.JANDEX,
 				beanClass,
-				findMetaConstraints( classInfo.classAnnotations(), beanClass ).collect( Collectors.toSet() )
+				constraints
 		) );
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/jandex/JandexMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/jandex/JandexMetaDataProviderTest.java
@@ -11,27 +11,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-import org.assertj.core.api.ListAssert;
+import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.jandex.ConstrainedFieldJandexBuilder;
 import org.hibernate.validator.internal.metadata.jandex.util.JandexHelper;
+import org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider;
 import org.hibernate.validator.internal.metadata.provider.JandexMetaDataProvider;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.test.internal.metadata.jandex.model.ConstrainedFieldJandexBuilderModel;
+
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+
+import org.assertj.core.api.ListAssert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -49,6 +60,7 @@ public class JandexMetaDataProviderTest {
 				Min.class,
 				Max.class,
 				NotNull.class,
+				NotBlank.class,
 				ConstrainedFieldJandexBuilderModel.class
 		};
 
@@ -68,12 +80,95 @@ public class JandexMetaDataProviderTest {
 	@Test
 	public void testGetConstrainedFields() {
 		JandexMetaDataProvider jandexMetaDataProvider = new JandexMetaDataProvider( new ConstraintHelper(), new JandexHelper(), indexView,
-				new AnnotationProcessingOptionsImpl(), new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ) );
+				new AnnotationProcessingOptionsImpl(), new ExecutableParameterNameProvider( new DefaultParameterNameProvider() )
+		);
 
 		List<BeanConfiguration<? super ConstrainedFieldJandexBuilderModel>> beanConfigurations =
 				jandexMetaDataProvider.getBeanConfigurationForHierarchy( ConstrainedFieldJandexBuilderModel.class );
 
 		assertThat( beanConfigurations ).isNotEmpty();
+	}
+
+	@Test
+	public void compareAnnotationAndJandex() {
+		ExecutableParameterNameProvider nameProvider = new ExecutableParameterNameProvider( new DefaultParameterNameProvider() );
+		ConstraintHelper constraintHelper = new ConstraintHelper();
+		AnnotationProcessingOptions annotationProcessingOptions = new AnnotationProcessingOptionsImpl();
+
+		AnnotationMetaDataProvider annotationMetaDataProvider = new AnnotationMetaDataProvider(
+				constraintHelper,
+				nameProvider,
+				annotationProcessingOptions
+		);
+
+		JandexMetaDataProvider jandexMetaDataProvider = new JandexMetaDataProvider(
+				constraintHelper,
+				new JandexHelper(),
+				indexView,
+				annotationProcessingOptions,
+				nameProvider
+		);
+
+		List<BeanConfiguration<? super ConstrainedFieldJandexBuilderModel>> jandexMetadata = jandexMetaDataProvider.getBeanConfigurationForHierarchy(
+				ConstrainedFieldJandexBuilderModel.class
+		);
+		List<BeanConfiguration<? super ConstrainedFieldJandexBuilderModel>> annotationMetadata = annotationMetaDataProvider.getBeanConfigurationForHierarchy(
+				ConstrainedFieldJandexBuilderModel.class
+		);
+
+		ListAssert<BeanConfiguration<? super ConstrainedFieldJandexBuilderModel>> jandexAssert = new ListAssert<>( jandexMetadata );
+		// Jandex metadata is missing Object bean configuration
+		//		jandexAssert.hasSize( annotationMetadata.size() );
+		//		jandexAssert.containsAll( annotationMetadata );
+
+		BeanConfiguration<? super ConstrainedFieldJandexBuilderModel> jandexConfig = jandexMetadata.get( 0 );
+		BeanConfiguration<? super ConstrainedFieldJandexBuilderModel> annotationConfig = annotationMetadata.get( 0 );
+
+		assertThat( jandexConfig.getConstrainedElements() ).hasSize( annotationConfig.getConstrainedElements().size() );
+		for ( ConstrainedElement constrainedElement : jandexConfig.getConstrainedElements() ) {
+			ConstrainedElement elem = find( annotationConfig.getConstrainedElements(), constrainedElement ).orElseThrow( IllegalStateException::new );
+			assertThat( elem.getCascadingTypeParameters().containsAll( constrainedElement.getCascadingTypeParameters() ) ).isTrue();
+			assertThat( elem.getCascadingTypeParameters() ).hasSize( constrainedElement.getCascadingTypeParameters().size() );
+
+			assertThat( elem.getConstraints().containsAll( constrainedElement.getConstraints() ) ).isTrue();
+			assertThat( elem.getConstraints() ).hasSize( constrainedElement.getConstraints().size() );
+
+			assertThat( elem.getTypeArgumentConstraints().containsAll( constrainedElement.getTypeArgumentConstraints() ) ).isTrue();
+			assertThat( elem.getTypeArgumentConstraints() ).hasSize( constrainedElement.getTypeArgumentConstraints().size() );
+
+			assertThat( elem.getKind().equals( constrainedElement.getKind() ) ).isTrue();
+
+			assertThat( elem.getGroupConversions() ).hasSize( constrainedElement.getGroupConversions().size() );
+			assertThat( elem.getGroupConversions().entrySet().containsAll( constrainedElement.getGroupConversions().entrySet() ) ).isTrue();
+		}
+	}
+
+	private Optional<ConstrainedElement> find(Set<ConstrainedElement> elementsToLookIn, ConstrainedElement elementToFind) {
+		return elementsToLookIn.stream()
+				.filter( element -> element.getClass().equals( elementToFind.getClass() ) )
+				.filter( element -> {
+					if ( element instanceof ConstrainedField && elementToFind instanceof ConstrainedField
+							&& ( (ConstrainedField) element ).getField().equals( ( (ConstrainedField) elementToFind ).getField() ) ) {
+						return true;
+					}
+					else if ( element instanceof ConstrainedParameter && elementToFind instanceof ConstrainedParameter
+							&& ( (ConstrainedParameter) element ).getExecutable().equals( ( (ConstrainedParameter) elementToFind ).getExecutable() ) ) {
+						return true;
+					}
+					else if ( element instanceof ConstrainedType && elementToFind instanceof ConstrainedType
+							&& ( (ConstrainedType) element ).getBeanClass().equals( ( (ConstrainedType) elementToFind ).getBeanClass() ) ) {
+						return true;
+					}
+					else if ( element instanceof ConstrainedExecutable && elementToFind instanceof ConstrainedExecutable
+							&& ( (ConstrainedExecutable) element ).getExecutable().equals( ( (ConstrainedExecutable) elementToFind ).getExecutable() ) ) {
+						return true;
+					}
+					else {
+						return false;
+					}
+
+				} )
+				.findAny();
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
 
         <!-- Version of Jandex to be used -->
         <jandex.version>2.0.3.Final</jandex.version>
+        <jandex-maven-plugin.version>1.0.5</jandex-maven-plugin.version>
 
         <!-- WildFly patching infrastructure -->
         <wildfly-patch-gen-maven-plugin.version>2.0.1.Alpha3</wildfly-patch-gen-maven-plugin.version>
@@ -904,6 +905,23 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                    <plugin>
+                        <groupId>org.jboss.jandex</groupId>
+                        <artifactId>jandex-maven-plugin</artifactId>
+                        <version>${jandex-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>make-index</id>
+                                <goals>
+                                    <goal>jandex</goal>
+                                </goals>
+                                <!-- phase is 'process-classes by default' -->
+                                <!--<configuration>-->
+                                    <!--<useDefaultExcludes>true</useDefaultExcludes>-->
+                                <!--</configuration>-->
+                            </execution>
+                        </executions>
+                    </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-644

Hi, 

I've updated a test a bit - and made a check between annotation based metadata and jandex based one. That test found a few issues:

- Object metadata is missing in collection returned by Jandex `getBeanConfigurationForHierarchy` (not fixed)
- `ConstrainedType` was retuned by Jandex provider even if there were no type constraints present.(fixed)
- type argument constraints contained different type to check (in the test case that we have it wanted to check on Optional, rather than String for the `private Optional<@NotBlank String> optional;`) (fixed)

also I've added a jandex-maven plugin but I haven't used the generated index yet. 
I was also thinking that maybe we can write a JMH test to see how annotation and jandex providers compares to each other ? Or you think that jandex provider is not yet ready for such tests ? 